### PR TITLE
Encode URL params when requesting entity UUIDs

### DIFF
--- a/tests/helpers/test_general_helpers.py
+++ b/tests/helpers/test_general_helpers.py
@@ -116,3 +116,22 @@ def test_get_entity_uuid(app_db_less, mocked_responses):
         )
 
         assert get_entity_uuid(entity, entity_name) == uuid
+
+
+def test_get_entity_uuid_with_ampersand(app_db_less, mocked_responses):
+    with app_db_less.app_context():
+        entity = "studies"
+        entity_name = "Heron Project R & D"
+        uuid = "12345"
+
+        # What the URL should look like after being encoded
+        ss_url = f"http://{current_app.config['SS_HOST']}/api/v2/studies?filter%5Bname%5D=Heron+Project+R+%26+D"
+
+        mocked_responses.add(
+            responses.GET,
+            ss_url,
+            body=f'{{"data": [{{"attributes": {{"uuid": "{uuid}"}}}}]}}',
+            status=HTTPStatus.OK,
+        )
+
+        assert get_entity_uuid(entity, entity_name) == uuid

--- a/wrangler/helpers/general_helpers.py
+++ b/wrangler/helpers/general_helpers.py
@@ -3,6 +3,7 @@ from enum import Enum
 from http import HTTPStatus
 from os.path import getsize, isfile, join
 from typing import Any, Dict, Tuple
+from urllib.parse import urlencode
 
 import requests
 from flask import current_app as app
@@ -85,7 +86,9 @@ def get_entity_uuid(entity: str, entity_name: str) -> str:
     """
     logger.info(f"Getting UUID for '{entity}' - '{entity_name}'")
 
-    url = f"http://{app.config['SS_HOST']}/api/v2/{entity}?filter[name]={entity_name}"
+    url = (
+        f"http://{app.config['SS_HOST']}/api/v2/{entity}?{urlencode({'filter[name]': entity_name})}"
+    )
 
     logger.debug(f"Sending GET to {url}")
 


### PR DESCRIPTION
Closes #

Changes proposed in this pull request:

*
*
* ...
